### PR TITLE
Tags for AWS IAM Users

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.11/master"
   enabled    = "${var.enabled}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,9 @@
 module "label" {
-  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.11/master"
-  enabled   = "${var.enabled}"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-
-  # name       = "${var.name}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.11/master"
+  enabled    = "${var.enabled}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
   delimiter  = "${var.delimiter}"
   attributes = "${var.attributes}"
   tags       = "${var.tags}"

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,10 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.11/master"
-  enabled    = "${var.enabled}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
+  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.11/master"
+  enabled   = "${var.enabled}"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+
+  # name       = "${var.name}"
   delimiter  = "${var.delimiter}"
   attributes = "${var.attributes}"
   tags       = "${var.tags}"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.11/master"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.11/master"
   enabled    = "${var.enabled}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  enabled    = "${var.enabled}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
-  enabled    = "${var.enabled}"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,14 @@
+module "label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  enabled    = "${var.enabled}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
+}
+
 resource "aws_iam_user" "default" {
   count = "${var.enabled == "true" ? 1 : 0}"
 
@@ -5,6 +16,7 @@ resource "aws_iam_user" "default" {
   path                 = "${var.path}"
   permissions_boundary = "${var.permissions_boundary}"
   force_destroy        = "${var.force_destroy}"
+  tags                 = "${module.label.tags}"
 }
 
 resource "aws_iam_user_login_profile" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,11 +10,6 @@ variable "stage" {
   default     = ""
 }
 
-variable "name" {
-  type        = "string"
-  description = "Name  (e.g. `app` or `cluster`)"
-}
-
 variable "delimiter" {
   type        = "string"
   default     = "-"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,44 @@
+variable "namespace" {
+  type        = string
+  description = "Namespace (e.g. `eg` or `cp`)"
+  default     = ""
+}
+
+variable "stage" {
+  type        = string
+  description = "Stage (e.g. `prod`, `dev`, `staging`, `infra`)"
+  default     = ""
+}
+
+variable "enabled" {
+  type        = bool
+  description = "Set to false to prevent the module from creating any resources"
+  default     = true
+}
+
+variable "name" {
+  type        = string
+  description = "Name  (e.g. `app` or `cluster`)"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `policy` or `role`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
+}
+
 variable "enabled" {
   description = "Whether to create the IAM user"
   default     = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -10,12 +10,6 @@ variable "stage" {
   default     = ""
 }
 
-variable "enabled" {
-  type        = bool
-  description = "Set to false to prevent the module from creating any resources"
-  default     = true
-}
-
 variable "name" {
   type        = string
   description = "Name  (e.g. `app` or `cluster`)"

--- a/variables.tf
+++ b/variables.tf
@@ -22,13 +22,13 @@ variable "delimiter" {
 }
 
 variable "attributes" {
-  type        = list("string")
+  type        = "list(string)"
   default     = []
   description = "Additional attributes (e.g. `policy` or `role`)"
 }
 
 variable "tags" {
-  type        = map("string")
+  type        = "map(string)"
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,13 +22,13 @@ variable "delimiter" {
 }
 
 variable "attributes" {
-  type        = "list(string)"
+  type        = "list"
   default     = []
   description = "Additional attributes (e.g. `policy` or `role`)"
 }
 
 variable "tags" {
-  type        = "map(string)"
+  type        = "map"
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,34 +1,34 @@
 variable "namespace" {
-  type        = string
+  type        = "string"
   description = "Namespace (e.g. `eg` or `cp`)"
   default     = ""
 }
 
 variable "stage" {
-  type        = string
+  type        = "string"
   description = "Stage (e.g. `prod`, `dev`, `staging`, `infra`)"
   default     = ""
 }
 
 variable "name" {
-  type        = string
+  type        = "string"
   description = "Name  (e.g. `app` or `cluster`)"
 }
 
 variable "delimiter" {
-  type        = string
+  type        = "string"
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
 }
 
 variable "attributes" {
-  type        = list(string)
+  type        = list("string")
   default     = []
   description = "Additional attributes (e.g. `policy` or `role`)"
 }
 
 variable "tags" {
-  type        = map(string)
+  type        = map("string")
   default     = {}
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }


### PR DESCRIPTION
You can use IAM tags to add custom attributes to an IAM entity (user) using a tag key–value pair. For example, to add Business Unit information to a user, you can add the tag key `BusinessUnit` and the tag value `engineering-operations`
```
module "charlie" {
  source                  = "git::https://github.com/lunarops/terraform-aws-iam-user.git?ref=0.11/master"
  name                    = "charlie@my-company.co"
  pgp_key                 = "keybase:charlie"
  password_reset_required = "false"
  password_length         = 32

  groups = [
    "dev-engineering-operations",
    "testing-engineering-operations",
    "staging-engineering-operations",
    "prod-engineering-operations",
  ]
  tags = {
    "BusinessUnit" = "engineering-operations"
    "Team"         = "alpha"
    "Project"      = "unicorn"
  }
}
```