### PR TITLE
feat: disables tamplate_files if `var.pgp_key` is not from keybase

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
-| keybase\_password\_decrypt\_command | Command to decrypt the Keybase encrypted password |
-| keybase\_password\_pgp\_message | PGP encrypted message (e.g. suitable for email exchanges) |
+| keybase\_password\_decrypt\_command | Command to decrypt the Keybase encrypted password. Returns empty string if pgp\_key is not from keybase |
+| keybase\_password\_pgp\_message | PGP encrypted message (e.g. suitable for email exchanges). Returns empty string if pgp\_key is not from keybase |
 | pgp\_key | PGP key used to encrypt sensitive data for this user |
 | user\_arn | The ARN assigned by AWS for this user |
 | user\_login\_profile\_encrypted\_password | The encrypted password, base64 encoded |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -46,8 +46,8 @@
 
 | Name | Description |
 |------|-------------|
-| keybase\_password\_decrypt\_command | Command to decrypt the Keybase encrypted password |
-| keybase\_password\_pgp\_message | PGP encrypted message (e.g. suitable for email exchanges) |
+| keybase\_password\_decrypt\_command | Command to decrypt the Keybase encrypted password. Returns empty string if pgp\_key is not from keybase |
+| keybase\_password\_pgp\_message | PGP encrypted message (e.g. suitable for email exchanges). Returns empty string if pgp\_key is not from keybase |
 | pgp\_key | PGP key used to encrypt sensitive data for this user |
 | user\_arn | The ARN assigned by AWS for this user |
 | user\_login\_profile\_encrypted\_password | The encrypted password, base64 encoded |

--- a/main.tf
+++ b/main.tf
@@ -27,11 +27,13 @@ resource "aws_iam_user_group_membership" "default" {
 
 locals {
   encrypted_password               = join("", aws_iam_user_login_profile.default.*.encrypted_password)
-  keybase_password_pgp_message     = data.template_file.keybase_password_pgp_message.rendered
-  keybase_password_decrypt_command = data.template_file.keybase_password_decrypt_command.rendered
+  pgp_key_is_keybase               = length(regexall("keybase:", var.pgp_key)) > 0 ? true : false
+  keybase_password_pgp_message     = join("", data.template_file.keybase_password_pgp_message.*.rendered)
+  keybase_password_decrypt_command = join("", data.template_file.keybase_password_decrypt_command.*.rendered)
 }
 
 data "template_file" "keybase_password_decrypt_command" {
+  count    = local.pgp_key_is_keybase ? 1 : 0
   template = file("${path.module}/templates/keybase_password_decrypt_command.sh")
 
   vars = {
@@ -40,6 +42,7 @@ data "template_file" "keybase_password_decrypt_command" {
 }
 
 data "template_file" "keybase_password_pgp_message" {
+  count    = local.pgp_key_is_keybase ? 1 : 0
   template = file("${path.module}/templates/keybase_password_pgp_message.txt")
 
   vars = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,11 +30,11 @@ output "pgp_key" {
 
 output "keybase_password_decrypt_command" {
   # https://stackoverflow.com/questions/36565256/set-the-aws-console-password-for-iam-user-with-terraform
-  description = "Command to decrypt the Keybase encrypted password"
+  description = "Command to decrypt the Keybase encrypted password. Returns empty string if pgp_key is not from keybase"
   value       = local.keybase_password_decrypt_command
 }
 
 output "keybase_password_pgp_message" {
-  description = "PGP encrypted message (e.g. suitable for email exchanges)"
+  description = "PGP encrypted message (e.g. suitable for email exchanges). Returns empty string if pgp_key is not from keybase"
   value       = local.keybase_password_pgp_message
 }

--- a/test/Makefile.alpine
+++ b/test/Makefile.alpine
@@ -2,4 +2,4 @@ ifneq (,$(wildcard /sbin/apk))
 ## Install all dependencies for alpine
 deps:: init
 	@apk add --update terraform-docs@cloudposse json2hcl@cloudposse
-ndif
+endif


### PR DESCRIPTION
## what
* Removes the keybase specific template file resources if the pgp_key input is not a keybase key

## why
* Keybase is no longer in business so folks are moving away from using keybase. These resources are not needed if using a standard PGP key, so let's get rid of them entirely to clean up the state. 


