### PR TITLE
fix: ignores password_reset_required change to support changes in AWS provider 4.x

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,10 @@ resource "aws_iam_user_login_profile" "default" {
   password_length         = var.password_length
   password_reset_required = var.password_reset_required
   depends_on              = [aws_iam_user.default]
+
+  lifecycle {
+    ignore_changes = [password_reset_required]
+  }
 }
 
 resource "aws_iam_user_group_membership" "default" {


### PR DESCRIPTION
## what
* Ignores password_reset_required change.

## why
* There is a bug/feature(?) in AWS provider 4.x  that causes undesired user update, see this open issue https://github.com/hashicorp/terraform-provider-aws/issues/23567. Know fix for now is to ignore this change.

## references
* https://github.com/hashicorp/terraform-provider-aws/issues/23567)

