### PR TITLE
fix: remove template provider from requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ Available targets:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,7 +6,6 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = ">= 2.0"


### PR DESCRIPTION
## what
* Remove not needed provider from requirements in `versions.tf` file

## why

template was not removed from `versions.tf` in PR that replaced `data "template_file"` with built-in function `templatefile`
> This module is using provider hashicorp/template https://registry.terraform.io/providers/hashicorp/template/latest/docs#deprecation which is deprecated
Provider hashicorp/template does not work on darwin_arm64 platform.


## references
* [use templatefile function instead of data resource ](https://github.com/cloudposse/terraform-aws-iam-user/pull/22)
* closes #20 

