### PR TITLE
Enable uploading a public ssh key into the user account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,14 @@ resource "aws_iam_user_login_profile" "default" {
   }
 }
 
+resource "aws_iam_user_ssh_key" "default" {
+  count = module.this.enabled && var.ssh_key_enabled == true ? 1 : 0
+
+  username   = aws_iam_user.default[count.index].name
+  encoding   = var.ssh_key_encoding
+  public_key = var.ssh_public_key
+}
+
 resource "aws_iam_user_group_membership" "default" {
   count      = module.this.enabled && length(var.groups) > 0 ? 1 : 0
   user       = aws_iam_user.default[count.index].name

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,7 @@ variable "force_destroy" {
 variable "pgp_key" {
   type        = string
   description = "Provide a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Required to encrypt password."
+  default     = ""
 }
 
 variable "password_reset_required" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,21 @@ variable "password_length" {
   description = "The length of the generated password"
   default     = 24
 }
+
+variable "ssh_key_enabled" {
+  description = "Whether to upload a public ssh key to the IAM user."
+  type        = bool
+  default     = false
+}
+
+variable "ssh_key_encoding" {
+  description = "The SSH key format. Valid options: SSH, PEM. The SSH format only accepts an RSA key: ssh-keygen -t rsa."
+  type        = string
+  default     = "SSH"
+}
+
+variable "ssh_public_key" {
+  description = "The actual SSH public key."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## what

This PR enables uploading of a public ssh key into the IAM user account. By default the ssh key uploading is disabled.

It also fixes a minor bug where, even when `login_profile_enabled = false`, the module would still ask for a value for the `pgp_key` variable.

## why

I need ssh keys attached to my IAM user accounts.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
